### PR TITLE
Add CC0 license file

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,0 +1,13 @@
+<p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license"
+     href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
+  </a>
+  <br />
+  To the extent possible under law,
+  <a rel="dct:publisher"
+     href="http://petewarden.typepad.com">
+    <span property="dct:title">Pete Warden</span></a>
+  has waived all copyright and related or neighboring rights to
+  <span property="dct:title">C hashmap</span>.
+</p>


### PR DESCRIPTION
This is to clarify the terms of "There are no restrictions on how you reuse this code."

As explained [here](http://www.rosenlaw.com/lj16.htm), there are several problems with simply stating that others can freely use a work without restriction:
- There's no guarantee that that permission cannot be retracted at any point
- Under jurisdictions that don't recognise public domain (e.g. USA), the author is still liable for warranty claims if the work causes harm, unintentional or not

Therefore it is useful to include a strong "public domain" license, as it protects users and authors.

I've chosen CC0 as it's very common, but others such as [unlicense](http://unlicense.org/) are also fine, as they contain the warranty disclaimer.

If you want to retain copyright, permissive licenses like MIT/X11 or BSD are also good.
